### PR TITLE
Ability to query without port

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,8 +55,10 @@ PORT = os.environ["NZBPO_PORT"]
 VERBOSE = os.environ["NZBPO_VERBOSE"] == "yes"
 COMMAND = os.environ.get("NZBCP_COMMAND") == "ping"
 
-URL = f"http://{HOST}:{PORT}"
-
+if PORT != "":
+    URL = f"http://{HOST}:{PORT}"
+else:
+    URL = f"http://{HOST}"
 
 if VERBOSE:
     print("[INFO] URL:", URL)


### PR DESCRIPTION
- Added a simple conditional to be able to query without using the port number (in cases where jellyfin is behind a reverse proxy). Triggered if entered port is blank (which right now would just query "https://host:"